### PR TITLE
Adjust layout switching keybinding

### DIFF
--- a/hypr/.config/hypr/hyprland.conf
+++ b/hypr/.config/hypr/hyprland.conf
@@ -212,7 +212,7 @@ device {
 # See https://wiki.hyprland.org/Configuring/Keywords/
 $mainMod = SUPER # Sets "Windows" key as main modifier
 
-bind = $mainMod,P,exec,hyprctl switchxkblayout current next
+bind = $mainMod,O,exec,hyprctl switchxkblayout current next
 bind = $mainMod,S,exec,hyprshot -m region --clipboard-only
 bind = $mainMod SHIFT,S,exec,hyprshot -m window --clipboard-only
 bind = $mainMod SHIFT,D,exec,DEV_ENV=/home/theprimeagen/personal/dev ~/personal/dev/dev-env


### PR DESCRIPTION
## Summary
- rebind the keyboard layout toggle from $mainMod+P to $mainMod+O so pseudotile remains on $mainMod+P

## Testing
- hyprctl reload *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ddf98aa88332849bcca53fd6396a