### PR TITLE
Adjust Mod4 mapping for real-prog-dvo-k layout

### DIFF
--- a/xkb/.config/xkb/symbols/real-prog-dvo-k
+++ b/xkb/.config/xkb/symbols/real-prog-dvo-k
@@ -9,6 +9,10 @@ xkb_symbols "real-prog-dvo-k" {
     // For example, remap LWIN to Alt_L if desired
     key <LWIN> { [ Alt_L, Meta_L ] };
 
+    clear Mod4;
+    modifier_map Mod4 { <HOME> };
+    modifier_map Mod1 { <LWIN> };
+
     key <TLDE> { [       dollar,        asciitilde, dead_grave, dead_tilde      ] };
 
     key <AE01> { [          plus,       1               ]       };


### PR DESCRIPTION
## Summary
- ensure the Home key provides the Mod4 modifier and map LWIN to Alt on the real-prog-dvo-k layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3f734f0548332b98cb240a716798b