### PR TITLE
Add Angular CLI tooling instructions and guard zsh completion

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -24,4 +24,7 @@ sudo dnf install -y \
   eza \            # Better ls
   zoxide \         # Better cd
   starship         # Better prompt
+
+# Angular CLI for frontend tooling
+sudo npm install -g @angular/cli
 ````

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -159,7 +159,9 @@ export PRTE_MCA_plm=ssh
 export PATH=/usr/lib64/openmpi/bin/prted:$PATH
 
 # Load Angular CLI autocompletion.
-source <(ng completion script)
+if command -v ng >/dev/null 2>&1; then
+  source <(ng completion script)
+fi
 
 # export NVM_DIR="$HOME/.config/nvm"
 # [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm


### PR DESCRIPTION
## Summary
- add Angular CLI global installation step to the development tooling instructions
- wrap Angular CLI completion sourcing in zshrc with a command availability check

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db1e84d2508332be1264c43d62ddd9