### PR TITLE
Configure Hyprland monitors layout

### DIFF
--- a/hypr/.config/hypr/hyprland.conf
+++ b/hypr/.config/hypr/hyprland.conf
@@ -18,9 +18,7 @@
 
 # Auto-generate monitor config on startup
 # exec-once = ~/.config/hypr/scripts/detect-monitors.sh
-# source = ~/.config/hypr/monitors.conf
-
-monitor=,preferred,auto,auto
+source = monitors.conf
 
 
 ###################

--- a/hypr/.config/hypr/monitors.conf
+++ b/hypr/.config/hypr/monitors.conf
@@ -1,1 +1,2 @@
-monitor=eDP-1, 2560x1440@60, 0x0, 1
+monitor = HDMI-A-1, 3840x2160@60, 0x0, 1
+monitor = eDP-1, 1920x1200@60, 3840x0, 1


### PR DESCRIPTION
## Summary
- define the HDMI-A-1 and eDP-1 monitors in monitors.conf with the external display positioned first
- source the monitors.conf file from hyprland.conf so the layout is loaded automatically

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db1e838dd4833298e5e9ac4a1a1d73